### PR TITLE
Squashed fixes.

### DIFF
--- a/attributes/node.rb
+++ b/attributes/node.rb
@@ -1,6 +1,6 @@
-default['prometheus_exporters']['node']['version'] = '0.14.0'
+default['prometheus_exporters']['node']['version'] = '0.15.1'
 default['prometheus_exporters']['node']['url'] = "https://github.com/prometheus/node_exporter/releases/download/v#{node['prometheus_exporters']['node']['version']}/node_exporter-#{node['prometheus_exporters']['node']['version']}.linux-amd64.tar.gz"
-default['prometheus_exporters']['node']['checksum'] = 'd5980bf5d0dc7214741b65d3771f08e6f8311c86531ae21c6ffec1d643549b2e'
+default['prometheus_exporters']['node']['checksum'] = '7ffb3773abb71dd2b2119c5f6a7a0dbca0cff34b24b2ced9e01d9897df61a127'
 
 default['prometheus_exporters']['node']['textfile_directory'] = '/var/lib/node_exporter/textfile_collector'
 
@@ -8,7 +8,7 @@ default['prometheus_exporters']['node']['ignored_net_devs'] = '^(weave|veth.*|do
 
 default['prometheus_exporters']['node']['ignored_mount_points'] = '^/(sys|proc|dev|host|etc|var/lib/docker|run|var/lib/lxcfs|var/lib/kubelet)($|/)'
 
-default['prometheus_exporters']['node']['collectors'] = %w(
+default['prometheus_exporters']['node']['collectors_enabled'] = %w(
   diskstats
   filefd
   filesystem
@@ -26,3 +26,5 @@ default['prometheus_exporters']['node']['collectors'] = %w(
   uname
   vmstat
 )
+
+default['prometheus_exporters']['node']['collectors_disabled'] = %w()

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'surrender@evilmartians.com'
 license          'All rights reserved'
 description      'Installs / configures Prometheus exporters'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.2'
+version          '0.4.4'
 
 supports 'ubuntu'
 supports 'centos', '>= 6.9'

--- a/resources/node.rb
+++ b/resources/node.rb
@@ -87,28 +87,28 @@ property :collector_filesystem_ignored_mount_points, String
 property :custom_options, String
 
 action :install do
-  options = "--web.listen-address=#{web_listen_address}"
-  options += " --web.telemetry-path=#{web_telemetry_path}"
-  options += " --log.level=#{log_level}"
-  options += " --log.format=#{log_format}"
-  options += " --collector.megacli.command=#{collector_megacli_command}" if collector_megacli_command
-  options += " --collector.ntp.server=#{collector_ntp_server}" if collector_ntp_server
-  options += " --collector.ntp.protocol-version=#{collector_ntp_protocol_version}" if collector_ntp_protocol_version
-  options += ' --collector.ntp.server-is-local' if collector_ntp_server_is_local
-  options += " --collector.ntp.ip-ttl=#{collector_ntp_ip_ttl}" if collector_ntp_ip_ttl
-  options += " --collector.ntp.max-distance=#{collector_ntp_max_distance}" if collector_ntp_max_distance
-  options += " --collector.ntp.local-offset-tolerance=#{collector_ntp_local_offset_tolerance}" if collector_ntp_local_offset_tolerance
-  options += " --path.procfs=#{path_procfs}" if path_procfs
-  options += " --path.sysfs=#{path_sysfs}" if path_sysfs
-  options += " --collector.textfile.directory=#{collector_textfile_directory}" if collector_textfile_directory
-  options += " --collector.netdev.ignored-devices='#{collector_netdev_ignored_devices}'" if collector_netdev_ignored_devices
-  options += " --collector.diskstats.ignored-devices='#{collector_diskstats_ignored_devices}'" if collector_diskstats_ignored_devices
-  options += " --collector.filesystem.ignored-fs-types='#{collector_filesystem_ignored_fs_types}'" if collector_filesystem_ignored_fs_types
-  options += " --collector.filesystem.ignored-mount-points='#{collector_filesystem_ignored_mount_points}'" if collector_filesystem_ignored_mount_points
-  options += " #{custom_options}" if custom_options
+  options = "--web.listen-address=#{new_resource.web_listen_address}"
+  options += " --web.telemetry-path=#{new_resource.web_telemetry_path}"
+  options += " --log.level=#{new_resource.log_level}"
+  options += " --log.format=#{new_resource.log_format}"
+  options += " --collector.megacli.command=#{new_resource.collector_megacli_command}" if new_resource.collector_megacli_command
+  options += " --collector.ntp.server=#{new_resource.collector_ntp_server}" if new_resource.collector_ntp_server
+  options += " --collector.ntp.protocol-version=#{new_resource.collector_ntp_protocol_version}" if new_resource.collector_ntp_protocol_version
+  options += ' --collector.ntp.server-is-local' if new_resource.collector_ntp_server_is_local
+  options += " --collector.ntp.ip-ttl=#{new_resource.collector_ntp_ip_ttl}" if new_resource.collector_ntp_ip_ttl
+  options += " --collector.ntp.max-distance=#{new_resource.collector_ntp_max_distance}" if new_resource.collector_ntp_max_distance
+  options += " --collector.ntp.local-offset-tolerance=#{new_resource.collector_ntp_local_offset_tolerance}" if new_resource.collector_ntp_local_offset_tolerance
+  options += " --path.procfs=#{new_resource.path_procfs}" if new_resource.path_procfs
+  options += " --path.sysfs=#{new_resource.path_sysfs}" if new_resource.path_sysfs
+  options += " --collector.textfile.directory=#{new_resource.collector_textfile_directory}" if new_resource.collector_textfile_directory
+  options += " --collector.netdev.ignored-devices='#{new_resource.collector_netdev_ignored_devices}'" if new_resource.collector_netdev_ignored_devices
+  options += " --collector.diskstats.ignored-devices='#{new_resource.collector_diskstats_ignored_devices}'" if new_resource.collector_diskstats_ignored_devices
+  options += " --collector.filesystem.ignored-fs-types='#{new_resource.collector_filesystem_ignored_fs_types}'" if new_resource.collector_filesystem_ignored_fs_types
+  options += " --collector.filesystem.ignored-mount-points='#{new_resource.collector_filesystem_ignored_mount_points}'" if new_resource.collector_filesystem_ignored_mount_points
+  options += " #{new_resource.custom_options}" if new_resource.custom_options
 
-  options += collectors_enabled.map { |c| " --collector.#{c}" }.join
-  options += collectors_disabled.map { |c| " --no-collector.#{c}" }.join
+  options += new_resource.collectors_enabled.map { |c| " --collector.#{c}" }.join
+  options += new_resource.collectors_disabled.map { |c| " --no-collector.#{c}" }.join unless new_resource.collectors_disabled.empty?
 
   # Download binary
   remote_file 'node_exporter' do
@@ -207,13 +207,13 @@ action :install do
   end
 
   directory 'collector_textfile_directory' do
-    path collector_textfile_directory
+    path new_resource.collector_textfile_directory
     owner 'root'
     group 'root'
     mode '0755'
     action :create
     recursive true
-    only_if { collector_textfile_directory && collector_textfile_directory != '' }
+    only_if { new_resource.collector_textfile_directory && new_resource.collector_textfile_directory != '' }
   end
 end
 


### PR DESCRIPTION
- Update to use collectors_enabled and connectors_disabled in attributes.
- Added .empty? guard for collectors_disabled in node resource.
- Bump node_exporter to version 0.15.1.
- Fix Chef 13 deprecation warnings about "new_resource".